### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 TARGET_NAME := handy
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 ifeq ($(platform),)
 	platform = unix

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,4 +1,8 @@
 LOCAL_PATH := $(call my-dir)
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 include $(CLEAR_VARS)
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -160,7 +160,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = "Handy";
-   info->library_version  = HANDYVER;
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version  = HANDYVER GIT_VERSION;
    info->need_fullpath    = true;
    info->valid_extensions = "lnx";
    info->block_extract = 0;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.