### PR TITLE
Add CORE_DIR to include path

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,5 +1,6 @@
 INCFLAGS = -I$(CORE_DIR)/lynx \
-           -I$(CORE_DIR)/libretro
+           -I$(CORE_DIR)/libretro \
+           -I$(CORE_DIR)
 
 ifneq (,$(findstring msvc2003,$(platform)))
    INCFLAGS += -I$(LIBRETRO_COMM_DIR)/include/compat/msvc


### PR DESCRIPTION
Android builds were broken due to missing blip/Stereo_Buffer.h.

Most likely other builds were succeeding because cwd was added to include paths and since the Android builds are done from the jni directory, the implicit include dir doesn't help.