### PR TITLE
Fix frame pacing

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -56,6 +56,23 @@ struct retro_core_option_v2_category option_cats_us[] = {
 
 struct retro_core_option_v2_definition option_defs_us[] = {
    {
+      "handy_refresh_rate",
+      "Video Refresh Rate",
+      NULL,
+      "Set video update frequency. Internally, the Lynx renders at a variable rate from 0 to 75Hz. Frames that occur between video update events will be dropped. Higher rates may increase video smoothness (depending on actual game frame rate) but can cause tearing on 60Hz displays.",
+      NULL,
+      NULL,
+      {
+         { "50",  "50Hz" },
+         { "60",  "60Hz" },
+         { "75",  "75Hz" },
+         { "100", "100Hz" },
+         { "120", "120Hz" },
+         { NULL, NULL },
+      },
+      "60"
+   },
+   {
       "handy_rot",
       "Display Rotation",
       NULL,

--- a/lynx/mikie.cpp
+++ b/lynx/mikie.cpp
@@ -1302,10 +1302,14 @@ ULONG CMikie::DisplayEndOfFrame(void)
          break;
    }
 
+   return 0;
+}
+
+void	CMikie::AudioEndOfFrame(void)
+{
    mikbuf.end_frame((gSystemCycleCount - gAudioLastUpdateCycle) / 4);
    gAudioBufferPointer = mikbuf.read_samples((blip_sample_t*) gAudioBuffer, HANDY_AUDIO_BUFFER_SIZE / 2);
-
-   return 0;
+   gAudioLastUpdateCycle = gSystemCycleCount;
 }
 
 // Peek/Poke memory handlers
@@ -2422,6 +2426,7 @@ inline void CMikie::Update(void)
 
    if(gSystemCycleCount>0xf0000000) {
       gSystemCycleCount-=0x80000000;
+      gLastRunCycleCount-=0x80000000;
       gThrottleNextCycleCheckpoint-=0x80000000;
       gAudioLastUpdateCycle-=0x80000000;
       mTIM_0_LAST_COUNT-=0x80000000;

--- a/lynx/mikie.h
+++ b/lynx/mikie.h
@@ -198,6 +198,7 @@ class CMikie : public CLynxBase
 
       ULONG	DisplayRenderLine(void);
       ULONG	DisplayEndOfFrame(void);
+      void	AudioEndOfFrame(void);
 
       inline void SetCPUSleep(void) {gSystemCPUSleep=TRUE;};
       inline void ClearCPUSleep(void) {gSystemCPUSleep=FALSE;gSystemCPUSleep_Saved=FALSE;};

--- a/lynx/system.cpp
+++ b/lynx/system.cpp
@@ -353,6 +353,7 @@ void CSystem::HLE_BIOS_FF80(void)
 void CSystem::Reset(void)
 {
    gSystemCycleCount=0;
+   gLastRunCycleCount=0;
    gNextTimerEvent=0;
    gCPUBootAddress=0;
    gBreakpointHit=FALSE;

--- a/lynx/system.h
+++ b/lynx/system.h
@@ -75,6 +75,7 @@
 
 #ifdef SYSTEM_CPP
 ULONG   gSystemCycleCount=0;
+ULONG   gLastRunCycleCount=0;
 ULONG   gNextTimerEvent=0;
 ULONG   gCPUWakeupTime=0;
 ULONG   gIRQEntryCycle=0;
@@ -104,6 +105,7 @@ CErrorInterface *gError=NULL;
 #else
 
 extern ULONG    gSystemCycleCount;
+extern ULONG    gLastRunCycleCount;
 extern ULONG    gNextTimerEvent;
 extern ULONG    gCPUWakeupTime;
 extern ULONG    gIRQEntryCycle;
@@ -209,6 +211,11 @@ class CSystem : public CSystemBase
          // If the CPU is asleep then skip to the next timer event
          if(gSystemCPUSleep)
             gSystemCycleCount=gNextTimerEvent;
+      }
+
+      inline void FetchAudioSamples(void)
+      {
+         mMikie->AudioEndOfFrame();
       }
 
       //


### PR DESCRIPTION
At present, this core has entirely broken frame pacing. The core reports a fixed refresh rate of 75Hz to the frontend, but the Lynx (and the internal emulation code) has a variable refresh rate of 0-75Hz; games can render at any rate they please. In `retro_run()`, the Lynx is always emulated until the next 'end of frame' event occurs - if a game renders at e.g. 25 fps, this means `retro_run()` will actually correspond to (1/25) seconds worth of Lynx runtime instead of the expected (1/75) seconds. In this case, the game is emulated too quickly - but it appears to run at the correct speed in the frontend because the core uploads an 'oversized' audio buffer (1/25 seconds worth of samples). RetroArch syncs on audio in such a way that when too many samples are received, the frontend runs in 'slow motion' - so the 'too fast emulation' + 'too many audio samples' effectively cancel out. But the results are awful. This is a significant violation of the libretro API, and it destroys the frontend's ability to properly synchronise audio and video, and to pace the frames correctly.

This PR modifies the run loop such that a fixed number of CPU cycles are emulated on each call of `retro_run()`, corresponding to the actual frontend output video refresh rate (which can be set via a new `Video Refresh Rate` core option). Thus the Lynx is always emulated at the correct speed, audio is always uploaded in batches of the correct size, and generated video frames are captured and output when available (and when the frontend can accept them).

The default `Video Refresh Rate` has been set to 60Hz, which provides smooth results for most games (and also eliminates screen tearing on 60Hz displays, which was an issue when the core only reported a 75Hz refresh rate). If a game has a higher frame rate than this (rare, but e.g. the intro and menus of California Games run at the full 75 fps), then 'excess' frames will be dropped. Users with 75Hz+ VRR displays can set higher refresh rates to improve video smoothness in these cases.