### PR TITLE
Improve save state efficiency

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -753,12 +753,14 @@ size_t retro_serialize_size(void)
 bool retro_serialize(void *data, size_t size)
 {
    LSS_FILE fp;
+
    if(!lynx)
       return false;
 
-   fp.memptr      = (UBYTE *) data;
+   fp.memptr      = (UBYTE *)data;
    fp.index       = 0;
    fp.index_limit = size;
+   fp.nul_stream  = 0;
 
    return lynx->ContextSave(&fp);
 }
@@ -766,12 +768,14 @@ bool retro_serialize(void *data, size_t size)
 bool retro_unserialize(const void *data, size_t size)
 {
    LSS_FILE fp;
+
    if(!lynx)
       return false;
 
-   fp.memptr      = (UBYTE *) data;
+   fp.memptr      = (UBYTE *)data;
    fp.index       = 0;
    fp.index_limit = size;
+   fp.nul_stream  = 0;
 
    return lynx->ContextLoad(&fp);
 }

--- a/lynx/system.h
+++ b/lynx/system.h
@@ -139,6 +139,7 @@ typedef struct lssfile
    UBYTE *memptr;
    ULONG index;
    ULONG index_limit;
+   UBYTE nul_stream;
 } LSS_FILE;
 
 int lss_read(void* dest, int varsize, int varcount, LSS_FILE *fp);


### PR DESCRIPTION
At present, the `retro_serialize()` function determines the save state size by allocating a temporary ~310kb buffer, writing an actual save state into it, then fetching the resultant buffer occupancy. This is terribly inefficient - and `retro_serialize()` is called 3 times every time a state is saved or loaded...

This PR modifies the serialisation memory stream code to allow a 'virtual' save state to be made - no buffer is required, and no data are copied. This means `retro_serialize()` can now fetch the save state size with no memory allocations and no wasted effort.